### PR TITLE
docs: correct uppercase/lowercase typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci](https://github.com/zavolanlab/zarp/workflows/ci/badge.svg?branch=dev)](https://github.com/zavolanlab/zarp/actions?query=workflow%3Aci)
+[![ci](https://github.com/zavolanlab/zarp/workflows/CI/badge.svg?branch=dev)](https://github.com/zavolanlab/zarp/actions?query=workflow%3Aci)
 [![GitHub license](https://img.shields.io/github/license/zavolanlab/zarp?color=orange)](https://github.com/zavolanlab/zarp/blob/dev/LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3891135.svg)](https://doi.org/10.5281/zenodo.3891135)
 


### PR DESCRIPTION
I overlooked that the `ci` in the README path to the shield graphics should be in fact `CI`.