### PR TITLE
refactor: unify snakemake versions between envs

### DIFF
--- a/install/environment.root.yml
+++ b/install/environment.root.yml
@@ -13,5 +13,5 @@ dependencies:
   - singularity=3.5.2
   - pip:
     - pandas==1.0.1
-    - snakemake==5.19.2
+    - snakemake==6.5.5
 


### PR DESCRIPTION
Update older _snakemake_ version for the _root_-dedicated _conda_ env.

Fixes #10 