### PR TITLE
chore: bump up TIN score module version

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -838,7 +838,7 @@ rule calculate_TIN_scores:
     threads: 8
 
     singularity:
-        "docker://quay.io/biocontainers/tin-score-calculation:0.5--pyh5e36f6f_0"
+        "docker://quay.io/biocontainers/tin-score-calculation:0.6.2--pyh5e36f6f_0"
 
     conda:
         os.path.join(workflow.basedir, "envs", "tin-score-calculation.yaml")

--- a/workflow/envs/tin-score-calculation.yaml
+++ b/workflow/envs/tin-score-calculation.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - tin-score-calculation=0.5
+  - tin-score-calculation=0.6.2
 ...


### PR DESCRIPTION
## Description

It seems that the previous version of TIN score repository had a bug related to multiprocessing; we fixed that bumped up the version, pushed new docker images and conda packages.
Here we just update the versions being pulled within _zarp_.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
