### PR TITLE
chore: bump TIN score version

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -838,7 +838,7 @@ rule calculate_TIN_scores:
     threads: 8
 
     singularity:
-        "docker://quay.io/biocontainers/tin-score-calculation:0.6.2--pyh5e36f6f_0"
+        "docker://quay.io/biocontainers/tin-score-calculation:0.6.3--pyh5e36f6f_0"
 
     conda:
         os.path.join(workflow.basedir, "envs", "tin-score-calculation.yaml")
@@ -848,6 +848,7 @@ rule calculate_TIN_scores:
         -i {input.bam} \
         -r {input.transcripts_bed12} \
         --names {params.sample} \
+        -p {threads} \
         {params.additional_params} \
         > {output.TIN_score};) 2> {log.stderr}"
 

--- a/workflow/envs/tin-score-calculation.yaml
+++ b/workflow/envs/tin-score-calculation.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - tin-score-calculation=0.6.2
+  - tin-score-calculation=0.6.3
 ...


### PR DESCRIPTION
## Description

After upgrade TIN score repo to `0.6.3` we need to update it here too.

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
