### PR TITLE
chore: change conda pkg manager to mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ to run the workflow on a high-performance computing (HPC) cluster.
 
 After installing Singularity, install the remaining dependencies with:
 ```bash
-conda env create -f install/environment.yml
+mamba env create -f install/environment.yml
 ```
 
 
@@ -101,7 +101,7 @@ run the workflow on your own computer), you can execute the following command
 to include Singularity in the Conda environment:
 
 ```bash
-conda env create -f install/environment.root.yml
+mamba env create -f install/environment.root.yml
 ```
 
 ## 4. Activate environment
@@ -121,7 +121,7 @@ will need to install these by executing the following command _in your active
 Conda environment_:
 
 ```bash
-conda env update -f install/environment.dev.yml
+mamba env update -f install/environment.dev.yml
 ```
 
 ## 6. Successful installation tests

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ will need to install these by executing the following command _in your active
 Conda environment_:
 
 ```bash
-mamba env update -f install/environment.dev.yml
+conda env update -f install/environment.dev.yml
 ```
 
 ## 6. Successful installation tests

--- a/README.md
+++ b/README.md
@@ -48,13 +48,21 @@ git clone https://github.com/zavolanlab/zarp.git
 cd zarp
 ```
 
-## 2. Conda installation
+## 2. Conda and Mamba installation
 
 Workflow dependencies can be conveniently installed with the [Conda][conda]
 package manager. We recommend that you install [Miniconda][miniconda-installation] 
 for your system (Linux). Be sure to select Python 3 option. 
 The workflow was built and tested with `miniconda 4.7.12`.
 Other versions are not guaranteed to work as expected.
+
+Given that Miniconda has been installed and is available in the current shell the first
+dependency for ZARP is the [Mamba][mamba] package manager, which needs to be installed in
+the `base` conda environment with:
+
+```bash
+conda install mamba -n base -c conda-forge
+```
 
 ## 3. Dependencies installation
 
@@ -232,6 +240,7 @@ your run.
 
 [conda]: <https://docs.conda.io/projects/conda/en/latest/index.html>
 [profiles]: <https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles>
+[mamba]: <https://github.com/mamba-org/mamba>
 [miniconda-installation]: <https://docs.conda.io/en/latest/miniconda.html>
 [rule-graph]: images/rule_graph.svg
 [zarp-logo]: images/zarp_logo.svg

--- a/install/environment.root.yml
+++ b/install/environment.root.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - graphviz=2.40.1
-  - jinja2=2.11.2
+  - jinja2=3.0.3
   - mamba=0.16.0
   - networkx=2.4
   - pip=20.0.2

--- a/install/environment.yml
+++ b/install/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - graphviz=2.40.1
-  - jinja2=2.11.2
+  - jinja2=3.0.3
   - mamba=0.16.0
   - networkx=2.4
   - pip=20.0.2

--- a/profiles/local-conda/config.yaml
+++ b/profiles/local-conda/config.yaml
@@ -3,7 +3,6 @@ cores: 4
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
-conda-frontend: "mamba"
 keep-going: true
 notemp: true
 no-hooks: true

--- a/profiles/local-conda/config.yaml
+++ b/profiles/local-conda/config.yaml
@@ -3,7 +3,7 @@ cores: 4
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
-conda-frontend: conda
+conda-frontend: "mamba"
 keep-going: true
 notemp: true
 no-hooks: true

--- a/profiles/slurm-conda/config.yaml
+++ b/profiles/slurm-conda/config.yaml
@@ -7,7 +7,6 @@ jobs: 256
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
-conda-frontend: "mamba"
 keep-going: true
 notemp: true
 no-hooks: true

--- a/profiles/slurm-conda/config.yaml
+++ b/profiles/slurm-conda/config.yaml
@@ -7,7 +7,7 @@ jobs: 256
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
-conda-frontend: conda
+conda-frontend: "mamba"
 keep-going: true
 notemp: true
 no-hooks: true


### PR DESCRIPTION
## Description

Fixes #18 

Strangely enough the previous problems with `cudadapt` output inconsistencies are no longer there. Maybe they have updated their build at the Anaconda Cloud(?)

Also Fixes #52, which we discovered by the way.

CC @ninsch3000 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation updated

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation
