### PR TITLE
Results dir

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -666,16 +666,6 @@ rule sort_genomic_alignment_samtools:
             "{sample}",
             "map_genome",
             "{sample}.{seqmode}.Aligned.sortedByCoord.out.bam"),
-        prefix_temp_dir = temp(
-            directory(
-                os.path.join(
-                    config["output_dir"],
-                    "samples",
-                    "{sample}",
-                    "map_genome",
-                    "{sample}.{seqmode}.sort_genomic_alignment_samtools")
-            )
-        )
 
     params:
         cluster_log_path = config["cluster_log_dir"],
@@ -706,10 +696,8 @@ rule sort_genomic_alignment_samtools:
             current_rule + ".{seqmode}.stdout.log")
 
     shell:
-        "(mkdir -p {output.prefix_temp_dir}; \
-        samtools sort \
+        "(samtools sort \
         -o {output.bam} \
-        -T {output.prefix_temp_dir} \
         -@ {threads} \
         {params.additional_params} \
         {input.bam}) \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -671,8 +671,9 @@ rule sort_genomic_alignment_samtools:
                 os.path.join(
                     config["output_dir"],
                     "samples",
-                    "{sample}.{seqmode}",
-                    "sort_genomic_alignment_samtools")
+                    "{sample}",
+                    "map_genome",
+                    "{sample}.{seqmode}.sort_genomic_alignment_samtools")
             )
         )
 


### PR DESCRIPTION
## Description
rule `sort_genomic_alignment_samtools` created an unnecessary subdirectory within `results/samples`.    
removed tmp dir for samtools sort as per default the tmp files are written alongside the out file [(see samtools sort manual)](http://www.htslib.org/doc/samtools-sort.html#OPTIONS)


Fixes #34 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation
