### PR TITLE
chore: turn MultiQC logo config params optional

### DIFF
--- a/resources/config_schema.json
+++ b/resources/config_schema.json
@@ -49,12 +49,10 @@
       "report_logo": {
         "type": "string",
         "description": "Relative path to image to display as logo in multiqc report.",
-        "default": "../../images/logo.128px.png"
       },
       "report_url": {
         "type": "string",
         "description": "URL to appear in multiqc report.",
-        "default": "https://zavolan.biozentrum.unibas.ch/"
       },
       "author_name": {
         "type": "string",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1815,9 +1815,9 @@ rule prepare_multiqc_config:
 
     params:
         cluster_log_path = config["cluster_log_dir"],
-        logo_path = config['report_logo'],
+        logo_path = config['report_logo'] if 'report_logo' in config else '',
         multiqc_intro_text = config['report_description'],
-        url = config['report_url'],
+        url = config['report_url'] if 'report_url' in config else '',
         author_name = config['author_name'],
         author_email = config['author_email'],
         additional_params = parse_rule_config(

--- a/workflow/scripts/zarp_multiqc_config.py
+++ b/workflow/scripts/zarp_multiqc_config.py
@@ -69,18 +69,26 @@ def main():
     analysis_type = "RNA-seq"
 
     intro_text = options.intro_text
-    custom_logo = options.custom_logo
-    url = options.url
     author_name = options.author_name
     author_email = options.author_email
+
+    if options.custom_logo == "":
+        custom_logo_line = ""
+        custom_logo_url_line = ""
+    else:
+        custom_logo_line = "custom_logo: \"" + options.custom_logo + "\""
+        if options.url == "":
+            custom_logo_url_line = ""
+        else:
+            custom_logo_url_line = "custom_logo_url: \"" + options.url + "\""
 
     config_string = f"""---
 
 title: "{title}"
 subtitle: "{subtitle}"
 intro_text: "{intro_text}"
-custom_logo: "{custom_logo}"
-custom_logo_url: "{url}"
+{custom_logo_line}
+{custom_logo_url_line}
 custom_logo_title: "{logo_title}"
 
 report_header_info:


### PR DESCRIPTION
## Description

Config params for MultiQC logo (img/url) are optional now: empty string or param absence result in no logo in the final report.

Fixes #72

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
