### PR TITLE
fix(htsinfer): initialize error flag in global scope

### DIFF
--- a/workflow/scripts/htsinfer_to_tsv.py
+++ b/workflow/scripts/htsinfer_to_tsv.py
@@ -12,7 +12,7 @@ logging.basicConfig(
             level=logging.INFO, 
             format='%(asctime)s %(levelname)s:%(message)s', datefmt='%Y-%m-%d %H:%M:%S ')
 LOGGER = logging.getLogger(__name__)
-
+e_flag = False
 
 
 def parse_arguments():
@@ -120,8 +120,6 @@ def should_i_flag(df, sample, param):
 def htsinfer_to_zarp(sample,jparams, samples_df):
     '''Translate htsinfer json output to zarp compatible row.'''  
 
-    # Flag errors
-    e_flag = False
     # need to swap filepaths?
     swap_paths = False
 

--- a/workflow/scripts/htsinfer_to_tsv.py
+++ b/workflow/scripts/htsinfer_to_tsv.py
@@ -223,7 +223,7 @@ def htsinfer_to_zarp(sample,jparams, samples_df):
     read_lengths = []
     read_lengths.append(jparams.library_stats.file_1.read_length.max)
     read_lengths.append(jparams.library_stats.file_2.read_length.max)
-    if read_lengths is not None:
+    if (read_lengths is not None) and (len(read_lengths) != 0):
         tparams["index_size"] = max([int(i) for i in read_lengths if i is not None])
     else:
         LOGGER.error("Read lengths (=index_size) could not be determined")


### PR DESCRIPTION
## Description

error flag was initialized to "False" inside a function; if that function is never called the variable e_flag is unbound; initializing it at top of script now

