### PR TITLE
fix: sort_bed_4_big memory increase as starting point

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2040,7 +2040,7 @@ rule sort_bed_4_big:
         os.path.join(workflow.basedir, "envs", "bedtools.yaml")
     
     resources:
-        mem_mb=lambda wildcards, attempt: 1024 * attempt
+        mem_mb=lambda wildcards, attempt: 2048 * attempt
 
     log:
         stderr = os.path.join(


### PR DESCRIPTION
## Description

Increased the starting required memory for the sort_bed_4_big rule, as it was running out of memory 
in mouse data.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes
