### PR TITLE
fix: gtf sorting

### DIFF
--- a/pipeline_documentation.md
+++ b/pipeline_documentation.md
@@ -15,6 +15,7 @@ on installation and usage please see [here](README.md).
   - [Sequencing mode-independent](#sequencing-mode-independent)
     - [`start`](#start)
     - [`create_index_star`](#create_index_star)
+    - [`sort_gtf`](#sort_gtf)
     - [`extract_transcriptome`](#extract_transcriptome)
     - [`concatenate_transcriptome_and_genome`](#concatenate_transcriptome_and_genome)
     - [`create_index_salmon`](#create_index_salmon)
@@ -164,6 +165,20 @@ Create index for [**STAR**](#third-party-software-used) short read aligner.
       [**prepare_bigWig**](#prepare_bigwig)
     - Chromosome name list `chrName.txt`; used in
       [**create_index_salmon**](#create_index_salmon)
+
+#### `sort_gtf`
+
+Sort provided gtf by chromosome, start and end coordinates. 
+
+> This process is executed once for the provided gtf annotation file.
+
+- **Input**
+  - Gene annotation file (`.gtf`)
+- **Output**
+  - Sorted Gene annotation file (`.gtf`); used in
+      [**extract_transcriptome**](#extract_transcriptome),
+      [**extract_transcripts_as_bed12**](#extract_transcripts_as_bed12), [**generate_alfa_index**](#generate_alfa_index),
+      [**quantification_salmon**](#quantification_salmon) and [**pe_quantification_salmon**](#pe_quantification_salmon)
 
 #### `extract_transcriptome`
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -400,6 +400,43 @@ rule create_index_star:
         1> {log.stdout} 2> {log.stderr}"
 
 
+current_rule = "sort_gtf"
+
+
+rule sort_gtf:
+    """
+        Sort gtf
+    """
+    input:
+        gtf=lambda wildcards: os.path.abspath(
+            get_sample("gtf", search_id="organism", search_value=wildcards.organism)
+        ),
+    output:
+        gtf=os.path.join(
+            config["star_indexes"],
+            "{organism}",
+            "sorted_genome.gtf",
+        ),
+    params:
+        cluster_log_path=config["cluster_log_dir"],
+    container:
+        "docker://ubuntu:focal-20210416"
+    threads: 1
+    resources:
+        mem_mb=lambda wildcards, attempt: 32000 * attempt,
+    log:
+        stderr=os.path.join(
+            config["log_dir"], f"{current_rule}_{{organism}}.stderr.log"
+        ),
+        stdout=os.path.join(
+            config["log_dir"], f"{current_rule}_{{organism}}.stdout.log"
+        ),
+    shell:
+        "(sort \
+        -k1,1 -k4,4n -k5,5nr {input.gtf} > {output.gtf} \
+        ) 1> {log.stdout} 2> {log.stderr}"
+
+
 current_rule = "extract_transcriptome"
 
 
@@ -411,8 +448,10 @@ rule extract_transcriptome:
         genome=lambda wildcards: get_sample(
             "genome", search_id="organism", search_value=wildcards.organism
         ),
-        gtf=lambda wildcards: get_sample(
-            "gtf", search_id="organism", search_value=wildcards.organism
+        gtf=lambda wildcards: os.path.join(
+            config["star_indexes"],
+            wildcards.organism,
+            "sorted_genome.gtf",
         ),
     output:
         transcriptome=temp(
@@ -602,7 +641,11 @@ rule extract_transcripts_as_bed12:
         Convert transcripts to BED12 format
     """
     input:
-        gtf=lambda wildcards: get_sample("gtf"),
+        gtf=lambda wildcards: os.path.join(
+            config["star_indexes"],
+            get_sample("organism"),
+            "sorted_genome.gtf",
+        ),
     output:
         bed12=temp(
             os.path.join(config["output_dir"], "full_transcripts_protein_coding.bed")
@@ -1019,7 +1062,11 @@ rule kallisto_merge_genes:
                 for i in pd.unique(samples_table.index.values)
             ],
         ),
-        gtf=get_sample("gtf"),
+        gtf=lambda wildcards: os.path.join(
+            config["star_indexes"],
+            get_sample("organism"),
+            "sorted_genome.gtf",
+        ),
     output:
         gn_tpm=os.path.join(config["output_dir"], "summary_kallisto", "genes_tpm.tsv"),
         gn_counts=os.path.join(
@@ -1447,9 +1494,7 @@ current_rule = "generate_alfa_index"
 rule generate_alfa_index:
     """ Generate ALFA index files from sorted GTF file """
     input:
-        gtf=lambda wildcards: os.path.abspath(
-            get_sample("gtf", search_id="organism", search_value=wildcards.organism)
-        ),
+        gtf=os.path.join(config["star_indexes"], "{organism}", "sorted_genome.gtf"),
         chr_len=os.path.join(
             config["star_indexes"],
             "{organism}",

--- a/workflow/rules/paired_end.snakefile.smk
+++ b/workflow/rules/paired_end.snakefile.smk
@@ -309,8 +309,10 @@ rule pe_quantification_salmon:
             "{sample}",
             "{sample}.fq2.pe.remove_polya.fastq.gz",
         ),
-        gtf=lambda wildcards: os.path.abspath(
-            get_sample("gtf", search_id="index", search_value=wildcards.sample)
+        gtf=lambda wildcards: os.path.join(
+            config["star_indexes"],
+            get_sample("organism", search_id="index", search_value=wildcards.sample),
+            "sorted_genome.gtf",
         ),
         index=lambda wildcards: os.path.join(
             config["salmon_indexes"],

--- a/workflow/rules/single_end.snakefile.smk
+++ b/workflow/rules/single_end.snakefile.smk
@@ -254,8 +254,10 @@ rule quantification_salmon:
             get_sample("kmer", search_id="index", search_value=wildcards.sample),
             "salmon.idx",
         ),
-        gtf=lambda wildcards: os.path.abspath(
-            get_sample("gtf", search_id="index", search_value=wildcards.sample)
+        gtf=lambda wildcards: os.path.join(
+            config["star_indexes"],
+            get_sample("organism", search_id="index", search_value=wildcards.sample),
+            "sorted_genome.gtf",
         ),
     output:
         gn_estimates=os.path.join(


### PR DESCRIPTION
## Description

The provided gtf annotation files provided by Ensembl can cause errors by ALFA. 
To avoid this issue, we introduce an extra rule that sorts the gtf file by chromosome, start and end. 

Fixes #113 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation updated

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/


Changes to workflow inputs (sample table and/or configs)
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * more fields/properties are required 
    * existing ones are dropped entirely 
* minor (add **feat:** in the beginning of the PR title)
    * optional fields/properties are added
    * required ones are made optional

Changes to workflow outputs
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * changes lead to removal/change of existing outputs (format or location)
* minor (add **feat:** in the beginning of the PR title)
    * additional outputs are generated
    * content (but not format or location) of existing outputs changes

Everything else: patch
(add any other conventional commit in the beginning of the PR title)


## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation
