### PR TITLE
fix: release notes categories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,8 @@ version: 1
 labels:
 - label: "breaking-change"
   title: "BREAKING CHANGE:.*"
+- label: "breaking-change"
+  title: ".*!:.*"
 - label: "enhancement"
   title: "^feat:.*"
   

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 version: 1
 labels:
-- label: "enhancement"
+- label: "breaking-change"
   title: "BREAKING CHANGE:.*"
 - label: "enhancement"
   title: "^feat:.*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+version: 1
+labels:
+- label: "enhancement"
+  title: "BREAKING CHANGE:.*"
+- label: "enhancement"
+  title: "^feat:.*"
+  

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,5 @@
 # .github/release.yml
+
 changelog:
   # exclude:
   #   labels:
@@ -8,10 +9,10 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - BREAKING CHANGE
+        - breaking-change
     - title: Exciting New Features 🎉
       labels:
-        - feat
+        - enhancement
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,0 @@
-version: 1
-labels:
-- label: "enhancement"
-  title: "BREAKING CHANGE:.*"
-- label: "enhancement"
-  title: "^feat:.*"
-  

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,7 @@
+version: 1
+labels:
+- label: "enhancement"
+  title: "BREAKING CHANGE:.*"
+- label: "enhancement"
+  title: "^feat:.*"
+  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: Label PRs
+
+on:
+- pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: srvaroa/labeler@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

- New labels have been manually added in the repo, called enhancement and breaking-change. 
- A new github action labeller attaches appropriate label according to PR-title
- The .github/release.yml has been modified to accept the approved label names to assign PRs to appropriate categories

Fixes #127

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Conventional Commits guidelines

- [X] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/


Changes to workflow inputs (sample table and/or configs)
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * more fields/properties are required 
    * existing ones are dropped entirely 
* minor (add **feat:** in the beginning of the PR title)
    * optional fields/properties are added
    * required ones are made optional

Changes to workflow outputs
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * changes lead to removal/change of existing outputs (format or location)
* minor (add **feat:** in the beginning of the PR title)
    * additional outputs are generated
    * content (but not format or location) of existing outputs changes

Everything else: patch
(add any other conventional commit in the beginning of the PR title)


## Checklist:

- [X] My code changes follow the style of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
