### PR TITLE
fix: do not use nan in htsinfer call

### DIFF
--- a/workflow/rules/htsinfer.smk
+++ b/workflow/rules/htsinfer.smk
@@ -8,7 +8,7 @@ config.setdefault("records", 100000)
 
 
 # global variables
-samples = pd.read_csv(config["samples"], header=0, index_col=0, sep="\t")
+samples = pd.read_csv(config["samples"], header=0, index_col=0, sep="\t", keep_default_na=False)
 OUT_DIR = config["outdir"]
 LOG_DIR = os.path.join(OUT_DIR, "logs")
 CLUSTER_LOG = os.path.join(LOG_DIR, "cluster_logs")


### PR DESCRIPTION
## Description

Don't keep default `nan` when reading samples table in `htsinfer.smk`, otherwise `nan` will be used instead of empty string in call to htsinfer.

Fixes #135 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Conventional Commits guidelines

- [ ] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/


Changes to workflow inputs (sample table and/or configs)
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * more fields/properties are required 
    * existing ones are dropped entirely 
* minor (add **feat:** in the beginning of the PR title)
    * optional fields/properties are added
    * required ones are made optional

Changes to workflow outputs
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * changes lead to removal/change of existing outputs (format or location)
* minor (add **feat:** in the beginning of the PR title)
    * additional outputs are generated
    * content (but not format or location) of existing outputs changes

Everything else: patch
(add any other conventional commit in the beginning of the PR title)


## Checklist:

- [ ] My code changes follow the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
