### PR TITLE
fix: allow global error flag variable to be changed inside function

### DIFF
--- a/workflow/rules/htsinfer.smk
+++ b/workflow/rules/htsinfer.smk
@@ -8,7 +8,7 @@ config.setdefault("records", 100000)
 
 
 # global variables
-samples = pd.read_csv(config["samples"], header=0, index_col=0, sep="\t")
+samples = pd.read_csv(config["samples"], header=0, index_col=0, sep="\t", keep_default_na=False)
 OUT_DIR = config["outdir"]
 LOG_DIR = os.path.join(OUT_DIR, "logs")
 CLUSTER_LOG = os.path.join(LOG_DIR, "cluster_logs")

--- a/workflow/scripts/htsinfer_to_tsv.py
+++ b/workflow/scripts/htsinfer_to_tsv.py
@@ -41,6 +41,7 @@ def parse_arguments():
 
 
 def main():
+    global e_flag
     # input parameters
     file_list = options.file_list
 
@@ -121,7 +122,7 @@ def should_i_flag(df, sample, param):
 
 def htsinfer_to_zarp(sample,jparams, samples_df):
     '''Translate htsinfer json output to zarp compatible row.'''  
-
+    global e_flag
     # need to swap filepaths?
     swap_paths = False
 

--- a/workflow/scripts/htsinfer_to_tsv.py
+++ b/workflow/scripts/htsinfer_to_tsv.py
@@ -49,7 +49,7 @@ def main():
     samples_df = samples_df.replace(r'^\s*$', np.nan, regex=True)
     # replace None
     samples_df =  samples_df.fillna(value=np.nan)
-
+    LOGGER.debug(f"samples_df: {samples_df}")
     outfile = options.output
 
     params_df = pd.DataFrame(columns=[
@@ -106,14 +106,16 @@ def main():
 
 def should_i_flag(df, sample, param):
     '''Only RAISE error if user hasn't specified value either'''
-
+    global e_flag
+    LOGGER.debug(f"flag before: {e_flag}")
     try:
         user_param = df.loc[sample,param]
     except KeyError:
         user_param = np.nan
-    if user_param is np.nan:
+    if np.isnan(user_param):
         e_flag = True
 
+    LOGGER.debug(f"flag after: {e_flag}")
     return e_flag
 
 


### PR DESCRIPTION
## Description
allow global error flag variable to be changed inside function. Added `global` keyword before variable inside the function definition, in order to allow the function to assign something to that variable. Additionally, changed test for nan to numpyesque call.

Fixes #136 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/


## Checklist:

- [ ] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
