### PR TITLE
perf: pin htsinfer docker image to latest

### DIFF
--- a/workflow/rules/htsinfer.smk
+++ b/workflow/rules/htsinfer.smk
@@ -47,7 +47,7 @@ rule run_htsinfer:
         cluster_log_path=CLUSTER_LOG,
     threads: 4
     singularity:
-        "docker://zavolab/htsinfer:0.9.0"
+        "docker://zavolab/htsinfer:latest"
     conda:
         os.path.join(workflow.basedir, "..", "envs", "htsinfer.yaml")
     log:
@@ -80,7 +80,7 @@ rule htsinfer_to_tsv:
         SAMPLES_OUT,
     threads: 4
     singularity:
-        "docker://zavolab/htsinfer:0.9.0"
+        "docker://zavolab/htsinfer:latest"
     conda:
         os.path.join(workflow.basedir, "..", "envs", "htsinfer.yaml")
     log:


### PR DESCRIPTION
## Description

Updated `htsinfer.smk` to pin the docker image for HTSinfer with the tag `latest` instead of `0.9.0`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [X] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [X] My code changes follow the style of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] I have updated the project's documentation
