### PR TITLE
fix: change htsinfer_to_tsv.py exit code

### DIFF
--- a/workflow/scripts/htsinfer_to_tsv.py
+++ b/workflow/scripts/htsinfer_to_tsv.py
@@ -161,13 +161,13 @@ def htsinfer_to_zarp(sample,jparams, samples_df):
 
     # fq1_3p (same for se and pe)
     f1_3p = jparams.read_layout.file_1.adapt_3
-    tparams["fq1_3p"] = "X" * 15 if f1_3p is None else f1_3p    
+    tparams["fq1_3p"] = np.nan if f1_3p is None else f1_3p    
     if f1_3p is None:
         LOGGER.warning("No 3p adapter for fq1 identified.")
             
     # fq2_3p
     f2_3p = jparams.read_layout.file_2.adapt_3
-    tparams["fq2_3p"] = "X" * 15 if f2_3p is None else f2_3p
+    tparams["fq2_3p"] = np.nan if f2_3p is None else f2_3p
     if f2_3p is None:
         # info only necessary for pe mode
         if tparams["seqmode"] == "pe":
@@ -249,4 +249,4 @@ if __name__ == '__main__':
         LOGGER.info("Finished script successfully.")
     else:
         LOGGER.error("Finished script BUT one or more required parameters could not be inferred, please check logs.")
-        sys.exit(1)
+        sys.exit(0)


### PR DESCRIPTION
## Description

When running the `htsinfer.smk` workflow, the script `htsinfer_to_tsv.py` exits with exit code 1 when one or more parameters cannot be inferred. Updated it to exit code 0, so the script is ran successfully, even if the inferred metadata is incomplete.
Also modified the table parameters, so if `fq1_3p` or `fq2_3p` cannot be inferred, NaN's are added instead of XXXs.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [X] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/


Changes to workflow inputs (sample table and/or configs)
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * more fields/properties are required 
    * existing ones are dropped entirely 
* minor (add **feat:** in the beginning of the PR title)
    * optional fields/properties are added
    * required ones are made optional

Changes to workflow outputs
* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * changes lead to removal/change of existing outputs (format or location)
* minor (add **feat:** in the beginning of the PR title)
    * additional outputs are generated
    * content (but not format or location) of existing outputs changes

Everything else: patch
(add any other conventional commit in the beginning of the PR title)


## Checklist:

- [X] My code changes follow the style of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] I have updated the project's documentation
