### PR TITLE
feat(htsinfer): interface log and cluster log dirs via config.yaml

### DIFF
--- a/tests/test_htsinfer_workflow/test.local.sh
+++ b/tests/test_htsinfer_workflow/test.local.sh
@@ -36,6 +36,8 @@ snakemake \
     --config outdir="results" \
              samples="../input_files/htsinfer_samples.tsv" \
              samples_out="samples_htsinfer.tsv" \
+             log_dir="logs" \
+             cluster_log_dir="logs/cluster_log" \
     --notemp \
     --keep-incomplete
 

--- a/workflow/rules/htsinfer.smk
+++ b/workflow/rules/htsinfer.smk
@@ -12,8 +12,8 @@ samples = pd.read_csv(
     config["samples"], header=0, index_col=0, sep="\t", keep_default_na=False
 )
 OUT_DIR = config["outdir"]
-LOG_DIR = os.path.join(OUT_DIR, "logs")
-CLUSTER_LOG = os.path.join(LOG_DIR, "cluster_logs")
+LOG_DIR = config["log_dir"]
+CLUSTER_LOG = config["cluster_log_dir"]
 # Write inferred params into new sample table.
 SAMPLES_OUT = os.path.join(OUT_DIR, config["samples_out"])
 

--- a/workflow/rules/htsinfer.smk
+++ b/workflow/rules/htsinfer.smk
@@ -59,7 +59,7 @@ rule run_htsinfer:
         set +e 
         htsinfer --records={params.records} --output-directory={params.outdir} --temporary-directory={resources.tmpdir} --cleanup-regime=KEEP_ALL --threads={threads} {input.fq1_path} {params.fq2_path} > {output.htsinfer_json} 2> {log.stderr}
         exitcode=$?
-        if [ $exitcode -eq 1]
+        if [ $exitcode -eq 1 ]
         then
             exit 0
         fi


### PR DESCRIPTION
## Description
reading log and cluster log directory paths from config, instead of building them inside the Snakefile. Like this, compatibility with other parts of ZARP-cli is ensured.

Fixes #145 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the project's documentation
