### PR TITLE
fix: pin Python version

### DIFF
--- a/install/environment.yml
+++ b/install/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>=3.10
+  - python>=3.10, <3.12
   - snakemake
   - graphviz


### PR DESCRIPTION
## Description

- Pin Python version to `<3.12` to avoid f-string related issues with newest Python release

Fixes #150 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [X] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [X] My code changes follow the style of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] I have updated the project's documentation
