### PR TITLE
fix: too little RAM allocated for BED sorting

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1906,7 +1906,7 @@ rule sort_bed_4_big:
     conda:
         os.path.join(workflow.basedir, "envs", "bedtools.yaml")
     resources:
-        mem_mb=lambda wildcards, attempt: 2048 * attempt,
+        mem_mb=lambda wildcards, attempt: 4096 * attempt,
     log:
         stderr=os.path.join(
             config["log_dir"],


### PR DESCRIPTION
## Description

- Increase default memory allocation for rule `sort_bed_4_big` from 2048 to 4096 Mb

Fixes #160 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation
