### PR TITLE
chore: deprecation warnings for get_sample()

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,7 +1,7 @@
 ## Function definitions
 def get_sample(column_id, search_id=None, search_value=None):
     """Get relevant per sample information from samples table"""
-    if search_id:
+    if search_id is not None:
         if search_id == "index":
             return str(
                 samples_table.loc[samples_table.index == search_value, column_id].iloc[

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -3,13 +3,19 @@ def get_sample(column_id, search_id=None, search_value=None):
     """Get relevant per sample information from samples table"""
     if search_id:
         if search_id == "index":
-            return str(samples_table[column_id][samples_table.index == search_value][0])
+            return str(
+                samples_table.loc[
+                    samples_table.index == search_value, column_id
+                ].iloc[0]
+            )
         else:
             return str(
-                samples_table[column_id][samples_table[search_id] == search_value][0]
+                samples_table.loc[
+                    samples_table[search_id] == search_value, column_id
+                ].iloc[0]
             )
     else:
-        return str(samples_table[column_id][0])
+        return str(samples_table.loc[0, column_id])
 
 
 def get_directionality(libtype, tool):
@@ -17,7 +23,8 @@ def get_directionality(libtype, tool):
     directionality = ""
 
     for key in directionality_dict.keys():
-        # Use the first of 'SF' or 'SR' that is found in libtype to look up directionality params for the current tool
+        # Use the first of 'SF' or 'SR' that is found in libtype to look up
+        # directionality params for the current tool
         if key in libtype:
             directionality = directionality_dict[key][tool]
             break

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -4,9 +4,9 @@ def get_sample(column_id, search_id=None, search_value=None):
     if search_id:
         if search_id == "index":
             return str(
-                samples_table.loc[
-                    samples_table.index == search_value, column_id
-                ].iloc[0]
+                samples_table.loc[samples_table.index == search_value, column_id].iloc[
+                    0
+                ]
             )
         else:
             return str(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -15,7 +15,7 @@ def get_sample(column_id, search_id=None, search_value=None):
                 ].iloc[0]
             )
     else:
-        return str(samples_table.loc[0, column_id])
+        return str(samples_table[column_id].iloc[0])
 
 
 def get_directionality(libtype, tool):


### PR DESCRIPTION
## Description

- Address deprecation warning issued by Pandas for treating keys as positions when using `Series.__getitem__` in function `get_sample()` defined in `workflow/rules/common.smk`

Fixes #158 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation