### PR TITLE
ci: allow workflow to force push CHANGELOG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
     steps:
       - name: Checkout ZARP repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.AUTO_COMMIT }}
 
       - name: Update CHANGELOG.md
         id: changelog
@@ -35,3 +42,4 @@ jobs:
           branch: main
           commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
           file_pattern: CHANGELOG.md
+          push_options: --force


### PR DESCRIPTION
## Description

This is untested, but implemented as described [here](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches).

Addresses #129, but will only close once the fix turns out to be effective (when a new release is triggered via tagging).

## Type of change

Please delete options that are not relevant.

- [x] CI fix

## Conventional Commits guidelines

- [x] I made sure the PR title follows the 
https://www.conventionalcommits.org/en/v1.0.0/

## Checklist:

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the project's documentation

## Summary by Sourcery

Enable force pushing of CHANGELOG updates in the deployment workflow

CI:
- Modify deployment workflow to allow force pushing CHANGELOG updates to protected branches using a custom token

Chores:
- Update GitHub Actions workflow permissions to enable write access for repository contents